### PR TITLE
[FLINK-36193] Supports applying TRUNCATE / DROP table ddl...

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.doris.sink;
+
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.exception.IllegalArgumentException;
+import org.apache.doris.flink.sink.schema.SchemaChangeManager;
+
+import java.io.IOException;
+
+import static org.apache.doris.flink.catalog.doris.DorisSystem.identifier;
+
+/** An enriched version of Doris' {@link SchemaChangeManager}. */
+public class DorisSchemaChangeManager extends SchemaChangeManager {
+    public DorisSchemaChangeManager(DorisOptions dorisOptions) {
+        super(dorisOptions);
+    }
+
+    public boolean truncateTable(String databaseName, String tableName)
+            throws IOException, IllegalArgumentException {
+        String createTableDDL =
+                "TRUNCATE TABLE " + identifier(databaseName) + "." + identifier(tableName);
+        return this.execute(createTableDDL, databaseName);
+    }
+
+    public boolean dropTable(String databaseName, String tableName)
+            throws IOException, IllegalArgumentException {
+        String createTableDDL =
+                "DROP TABLE " + identifier(databaseName) + "." + identifier(tableName);
+        return this.execute(createTableDDL, databaseName);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
@@ -33,15 +33,15 @@ public class DorisSchemaChangeManager extends SchemaChangeManager {
 
     public boolean truncateTable(String databaseName, String tableName)
             throws IOException, IllegalArgumentException {
-        String createTableDDL =
+        String truncateTableDDL =
                 "TRUNCATE TABLE " + identifier(databaseName) + "." + identifier(tableName);
-        return this.execute(createTableDDL, databaseName);
+        return this.execute(truncateTableDDL, databaseName);
     }
 
     public boolean dropTable(String databaseName, String tableName)
             throws IOException, IllegalArgumentException {
-        String createTableDDL =
+        String dropTableDDL =
                 "DROP TABLE " + identifier(databaseName) + "." + identifier(tableName);
-        return this.execute(createTableDDL, databaseName);
+        return this.execute(dropTableDDL, databaseName);
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
@@ -472,9 +472,11 @@ public class DorisMetadataApplierITCase extends DorisSinkTestBase {
                         DataChangeEvent.insertEvent(tableId, generate(schema, 3, 4.5, "Cecily")),
                         DataChangeEvent.insertEvent(tableId, generate(schema, 4, 5.6, "Derrida")));
         runJobWithEvents(truncateTestingEvents);
-        assertEqualsInAnyOrder(
+        waitAndVerify(
+                tableId,
+                3,
                 Arrays.asList("3 | 4.5 | Cecily", "4 | 5.6 | Derrida"),
-                fetchTableContent(tableId, 3));
+                DATABASE_OPERATION_TIMEOUT_SECONDS * 1000L);
     }
 
     @Test

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -326,16 +326,6 @@ public class PaimonSinkITCase {
         metadataApplier.applySchemaChange(truncateTableEvent);
         Assertions.assertThat(fetchResults(table1)).isEmpty();
 
-        // FIXME: This check will fail when deleteVector is true
-        writeAndCommit(
-                writer,
-                committer,
-                generateInsert(
-                        table1, Arrays.asList(Tuple2.of(STRING(), "7"), Tuple2.of(STRING(), "7"))));
-
-        Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(Collections.singletonList(Row.ofKind(RowKind.INSERT, "7", "7")));
-
         DropTableEvent dropTableEvent = new DropTableEvent(table1);
         metadataApplier.applySchemaChange(dropTableEvent);
         Assertions.assertThatThrownBy(() -> fetchResults(table1))

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -317,7 +317,11 @@ public class PaimonSinkITCase {
         if (enableDeleteVector) {
             Assertions.assertThatThrownBy(
                             () -> metadataApplier.applySchemaChange(truncateTableEvent))
-                    .isExactlyInstanceOf(UnsupportedSchemaChangeEventException.class);
+                    .isExactlyInstanceOf(SchemaEvolveException.class)
+                    .cause()
+                    .isExactlyInstanceOf(UnsupportedSchemaChangeEventException.class)
+                    .extracting("exceptionMessage")
+                    .isEqualTo("Unable to truncate a table with deletion vectors enabled.");
         } else {
             metadataApplier.applySchemaChange(truncateTableEvent);
             Assertions.assertThat(fetchResults(table1)).isEmpty();

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -187,10 +187,8 @@ public class PaimonSinkITCase {
         writeAndCommit(
                 writer, committer, createTestEvents(enableDeleteVector).toArray(new Event[0]));
         Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(
-                        Arrays.asList(
-                                Row.ofKind(RowKind.INSERT, "1", "1"),
-                                Row.ofKind(RowKind.INSERT, "2", "2")));
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.INSERT, "1", "1"), Row.ofKind(RowKind.INSERT, "2", "2"));
 
         // delete
         writeAndCommit(
@@ -200,7 +198,7 @@ public class PaimonSinkITCase {
                         table1, Arrays.asList(Tuple2.of(STRING(), "1"), Tuple2.of(STRING(), "1"))));
 
         Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(Collections.singletonList(Row.ofKind(RowKind.INSERT, "2", "2")));
+                .containsExactlyInAnyOrder(Row.ofKind(RowKind.INSERT, "2", "2"));
 
         // update
         writeAndCommit(
@@ -211,22 +209,18 @@ public class PaimonSinkITCase {
                         Arrays.asList(Tuple2.of(STRING(), "2"), Tuple2.of(STRING(), "2")),
                         Arrays.asList(Tuple2.of(STRING(), "2"), Tuple2.of(STRING(), "x"))));
         Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(Collections.singletonList(Row.ofKind(RowKind.INSERT, "2", "x")));
+                .containsExactlyInAnyOrder(Row.ofKind(RowKind.INSERT, "2", "x"));
 
         if (enableDeleteVector) {
-        Assertions.assertThat(fetchResults(
-                TableId.tableId("test", "`table1$files`")
-        )).containsExactly(
-                Row.ofKind(RowKind.INSERT, 1L), Row.ofKind(RowKind.INSERT, 3L)
-        );
+            Assertions.assertThat(fetchMaxSequenceNumber(table1.getTableName()))
+                    .containsExactlyInAnyOrder(
+                            Row.ofKind(RowKind.INSERT, 1L), Row.ofKind(RowKind.INSERT, 3L));
         } else {
-            Assertions.assertThat(fetchResults(
-                    TableId.tableId("test", "`table1$files`")
-            )).containsExactly(
-                    Row.ofKind(RowKind.INSERT, 1L),
-                    Row.ofKind(RowKind.INSERT, 2L),
-                    Row.ofKind(RowKind.INSERT, 3L)
-            );
+            Assertions.assertThat(fetchMaxSequenceNumber(table1.getTableName()))
+                    .containsExactlyInAnyOrder(
+                            Row.ofKind(RowKind.INSERT, 1L),
+                            Row.ofKind(RowKind.INSERT, 2L),
+                            Row.ofKind(RowKind.INSERT, 3L));
         }
     }
 
@@ -246,10 +240,8 @@ public class PaimonSinkITCase {
         writeAndCommit(
                 writer, committer, createTestEvents(enableDeleteVector).toArray(new Event[0]));
         Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(
-                        Arrays.asList(
-                                Row.ofKind(RowKind.INSERT, "1", "1"),
-                                Row.ofKind(RowKind.INSERT, "2", "2")));
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.INSERT, "1", "1"), Row.ofKind(RowKind.INSERT, "2", "2"));
 
         // 2. receive DataChangeEvents and SchemaChangeEvents during one checkpoint
         writeAndCommit(
@@ -278,12 +270,11 @@ public class PaimonSinkITCase {
                                 Tuple2.of(STRING(), "4"))));
 
         Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(
-                        Arrays.asList(
-                                Row.ofKind(RowKind.INSERT, "1", "1", null),
-                                Row.ofKind(RowKind.INSERT, "2", "2", null),
-                                Row.ofKind(RowKind.INSERT, "3", "3", null),
-                                Row.ofKind(RowKind.INSERT, "4", "4", "4")));
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.INSERT, "1", "1", null),
+                        Row.ofKind(RowKind.INSERT, "2", "2", null),
+                        Row.ofKind(RowKind.INSERT, "3", "3", null),
+                        Row.ofKind(RowKind.INSERT, "4", "4", "4"));
 
         // 2. receive DataChangeEvents and SchemaChangeEvents during one checkpoint
         writeAndCommit(
@@ -313,14 +304,13 @@ public class PaimonSinkITCase {
         Assertions.assertThat(result).hasSameSizeAs(deduplicated);
 
         Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(
-                        Arrays.asList(
-                                Row.ofKind(RowKind.INSERT, "1", null),
-                                Row.ofKind(RowKind.INSERT, "2", null),
-                                Row.ofKind(RowKind.INSERT, "3", null),
-                                Row.ofKind(RowKind.INSERT, "4", "4"),
-                                Row.ofKind(RowKind.INSERT, "5", "5"),
-                                Row.ofKind(RowKind.INSERT, "6", "6")));
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.INSERT, "1", null),
+                        Row.ofKind(RowKind.INSERT, "2", null),
+                        Row.ofKind(RowKind.INSERT, "3", null),
+                        Row.ofKind(RowKind.INSERT, "4", "4"),
+                        Row.ofKind(RowKind.INSERT, "5", "5"),
+                        Row.ofKind(RowKind.INSERT, "6", "6"));
 
         TruncateTableEvent truncateTableEvent = new TruncateTableEvent(table1);
         metadataApplier.applySchemaChange(truncateTableEvent);
@@ -366,12 +356,10 @@ public class PaimonSinkITCase {
         writeAndCommit(writer, committer, testEvents.toArray(new Event[0]));
 
         Assertions.assertThat(fetchResults(table1))
-                .isEqualTo(
-                        Arrays.asList(
-                                Row.ofKind(RowKind.INSERT, "1", "1"),
-                                Row.ofKind(RowKind.INSERT, "2", "2")));
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.INSERT, "1", "1"), Row.ofKind(RowKind.INSERT, "2", "2"));
         Assertions.assertThat(fetchResults(table2))
-                .isEqualTo(Collections.singletonList(Row.ofKind(RowKind.INSERT, "1", "1")));
+                .containsExactlyInAnyOrder(Row.ofKind(RowKind.INSERT, "1", "1"));
     }
 
     private static void commit(
@@ -398,6 +386,18 @@ public class PaimonSinkITCase {
     private List<Row> fetchResults(TableId tableId) {
         List<Row> results = new ArrayList<>();
         tEnv.sqlQuery("select * from paimon_catalog." + tableId.toString())
+                .execute()
+                .collect()
+                .forEachRemaining(results::add);
+        return results;
+    }
+
+    private List<Row> fetchMaxSequenceNumber(String tableName) {
+        List<Row> results = new ArrayList<>();
+        tEnv.sqlQuery(
+                        "select max_sequence_number from paimon_catalog.test.`"
+                                + tableName
+                                + "$files`")
                 .execute()
                 .collect()
                 .forEachRemaining(results::add);
@@ -508,7 +508,7 @@ public class PaimonSinkITCase {
                 .collect()
                 .forEachRemaining(result::add);
         Assertions.assertThat(result)
-                .containsExactly(
+                .containsExactlyInAnyOrder(
                         Row.ofKind(RowKind.INSERT, "1", "1"),
                         Row.ofKind(RowKind.INSERT, "2", "2"),
                         Row.ofKind(RowKind.INSERT, "3", "3"),

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSink.java
@@ -24,7 +24,6 @@ import org.apache.flink.cdc.common.sink.EventSinkProvider;
 import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
 
-import com.starrocks.connector.flink.catalog.StarRocksCatalog;
 import com.starrocks.connector.flink.table.sink.SinkFunctionFactory;
 import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
 import com.starrocks.connector.flink.table.sink.v2.StarRocksSink;
@@ -72,8 +71,8 @@ public class StarRocksDataSink implements DataSink, Serializable {
 
     @Override
     public MetadataApplier getMetadataApplier() {
-        StarRocksCatalog catalog =
-                new StarRocksCatalog(
+        StarRocksEnrichedCatalog catalog =
+                new StarRocksEnrichedCatalog(
                         sinkOptions.getJdbcUrl(),
                         sinkOptions.getUsername(),
                         sinkOptions.getPassword());

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksEnrichedCatalog.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksEnrichedCatalog.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.starrocks.sink;
+
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import com.starrocks.connector.flink.catalog.StarRocksCatalog;
+import com.starrocks.connector.flink.catalog.StarRocksCatalogException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/** An enriched {@code StarRocksCatalog} with more schema evolution abilities. */
+public class StarRocksEnrichedCatalog extends StarRocksCatalog {
+    public StarRocksEnrichedCatalog(String jdbcUrl, String username, String password) {
+        super(jdbcUrl, username, password);
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(StarRocksEnrichedCatalog.class);
+
+    public void truncateTable(String databaseName, String tableName)
+            throws StarRocksCatalogException {
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(databaseName),
+                "Database name cannot be null or empty.");
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(tableName),
+                "Table name cannot be null or empty.");
+        String alterSql = this.buildTruncateTableSql(databaseName, tableName);
+        try {
+            // TRUNCATE TABLE is not regarded as a column-based schema change for StarRocks, so
+            // there's no need to check the evolution state.
+            executeUpdateStatement(alterSql);
+        } catch (Exception e) {
+            LOG.error(
+                    "Failed to truncate table `{}`.`{}`. SQL executed: {}",
+                    databaseName,
+                    tableName,
+                    alterSql);
+            throw new StarRocksCatalogException(
+                    String.format("Failed to truncate table `%s`.`%s`.", databaseName, tableName),
+                    e);
+        }
+    }
+
+    public void dropTable(String databaseName, String tableName) throws StarRocksCatalogException {
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(databaseName),
+                "Database name cannot be null or empty.");
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(tableName),
+                "Table name cannot be null or empty.");
+        String alterSql = this.buildDropTableSql(databaseName, tableName);
+        try {
+            // like TRUNCATE TABLE, DROP TABLE isn't a column-affecting operation and `executeAlter`
+            // method isn't appropriate.
+            executeUpdateStatement(alterSql);
+        } catch (Exception e) {
+            LOG.error(
+                    "Failed to drop table `{}`.`{}`. SQL executed: {}",
+                    databaseName,
+                    tableName,
+                    alterSql);
+            throw new StarRocksCatalogException(
+                    String.format("Failed to drop table `%s`.`%s`.", databaseName, tableName), e);
+        }
+    }
+
+    private String buildTruncateTableSql(String databaseName, String tableName) {
+        return String.format("TRUNCATE TABLE `%s`.`%s`;", databaseName, tableName);
+    }
+
+    private String buildDropTableSql(String databaseName, String tableName) {
+        return String.format("DROP TABLE `%s`.`%s`;", databaseName, tableName);
+    }
+
+    private void executeUpdateStatement(String sql) throws StarRocksCatalogException {
+        try {
+            Method m =
+                    getClass()
+                            .getSuperclass()
+                            .getDeclaredMethod("executeUpdateStatement", String.class);
+            m.setAccessible(true);
+            m.invoke(this, sql);
+        } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/MockStarRocksCatalog.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/MockStarRocksCatalog.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /** Mock {@link StarRocksCatalog} for testing. */
-public class MockStarRocksCatalog extends StarRocksCatalog {
+public class MockStarRocksCatalog extends StarRocksEnrichedCatalog {
 
     /** database name -> table name -> table. */
     private final Map<String, Map<String, StarRocksTable>> tables;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
@@ -20,18 +20,24 @@ package org.apache.flink.cdc.connectors.starrocks.sink;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.data.binary.BinaryRecordData;
+import org.apache.flink.cdc.common.data.binary.BinaryStringData;
 import org.apache.flink.cdc.common.event.AddColumnEvent;
 import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.DropColumnEvent;
+import org.apache.flink.cdc.common.event.DropTableEvent;
 import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEventTypeFamily;
 import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.event.TruncateTableEvent;
 import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
 import org.apache.flink.cdc.common.schema.PhysicalColumn;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.sink.DataSink;
+import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.composer.definition.SinkDef;
 import org.apache.flink.cdc.composer.flink.coordination.OperatorIDGenerator;
@@ -39,11 +45,14 @@ import org.apache.flink.cdc.composer.flink.translator.DataSinkTranslator;
 import org.apache.flink.cdc.composer.flink.translator.SchemaOperatorTranslator;
 import org.apache.flink.cdc.connectors.starrocks.sink.utils.StarRocksContainer;
 import org.apache.flink.cdc.connectors.starrocks.sink.utils.StarRocksSinkTestBase;
+import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -350,8 +359,70 @@ public class StarRocksMetadataApplierITCase extends StarRocksSinkTestBase {
         runJobWithEvents(generateNarrowingAlterColumnTypeEvents(tableId));
     }
 
+    @Test
+    public void testStarRocksTruncateTable() throws Exception {
+        TableId tableId =
+                TableId.tableId(
+                        StarRocksContainer.STARROCKS_DATABASE_NAME,
+                        StarRocksContainer.STARROCKS_TABLE_NAME);
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        List<Event> truncateTableTestingEvents =
+                Arrays.asList(
+                        new CreateTableEvent(tableId, schema),
+                        DataChangeEvent.insertEvent(tableId, generate(schema, 1, 2.3, "Alice")),
+                        DataChangeEvent.insertEvent(tableId, generate(schema, 2, 3.4, "Bob")),
+                        new TruncateTableEvent(tableId),
+                        DataChangeEvent.insertEvent(tableId, generate(schema, 3, 4.5, "Cecily")),
+                        DataChangeEvent.insertEvent(tableId, generate(schema, 4, 5.6, "Derrida")));
+        runJobWithEvents(truncateTableTestingEvents);
+
+        assertEqualsInAnyOrder(
+                Arrays.asList("3 | 4.5 | Cecily", "4 | 5.6 | Derrida"),
+                fetchTableContent(tableId, 3));
+    }
+
+    @Test
+    public void testStarRocksDropTable() throws Exception {
+        TableId tableId =
+                TableId.tableId(
+                        StarRocksContainer.STARROCKS_DATABASE_NAME,
+                        StarRocksContainer.STARROCKS_TABLE_NAME);
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        List<Event> dropTableTestingEvents =
+                Arrays.asList(
+                        new CreateTableEvent(tableId, schema),
+                        DataChangeEvent.insertEvent(tableId, generate(schema, 1, 2.3, "Alice")),
+                        DataChangeEvent.insertEvent(tableId, generate(schema, 2, 3.4, "Bob")),
+                        new DropTableEvent(tableId));
+        runJobWithEvents(dropTableTestingEvents);
+
+        Assert.assertThrows(
+                String.format(
+                        "Getting analyzing error. Detail message: Unknown table '%s.%s'.",
+                        tableId.getSchemaName(), tableId.getTableName()),
+                MySQLSyntaxErrorException.class,
+                () -> fetchTableContent(tableId, 3));
+    }
+
     private void runJobWithEvents(List<Event> events) throws Exception {
-        DataStream<Event> stream = env.fromCollection(events, TypeInformation.of(Event.class));
+        DataStream<Event> stream =
+                env.fromCollection(events, TypeInformation.of(Event.class)).setParallelism(1);
 
         Configuration config =
                 new Configuration()
@@ -391,5 +462,17 @@ public class StarRocksMetadataApplierITCase extends StarRocksSinkTestBase {
                 schemaOperatorIDGenerator.generate());
 
         env.execute("StarRocks Schema Evolution Test");
+    }
+
+    BinaryRecordData generate(Schema schema, Object... fields) {
+        return (new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0])))
+                .generate(
+                        Arrays.stream(fields)
+                                .map(
+                                        e ->
+                                                (e instanceof String)
+                                                        ? BinaryStringData.fromString((String) e)
+                                                        : e)
+                                .toArray());
     }
 }

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MySqlToDorisE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MySqlToDorisE2eITCase.java
@@ -34,7 +34,6 @@ import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.lifecycle.Startables;
 
@@ -46,7 +45,6 @@ import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,10 +52,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /** End-to-end tests for mysql cdc to Doris pipeline job. */
 @RunWith(Parameterized.class)
@@ -70,8 +67,8 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
     protected static final String MYSQL_TEST_USER = "mysqluser";
     protected static final String MYSQL_TEST_PASSWORD = "mysqlpw";
     protected static final String MYSQL_DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
-    public static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
-    public static final int TESTCASE_TIMEOUT_SECONDS = 60;
+    public static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofSeconds(240);
+    public static final Duration DEFAULT_RESULT_VERIFY_TIMEOUT = Duration.ofSeconds(30);
 
     @ClassRule
     public static final MySqlContainer MYSQL =
@@ -84,14 +81,11 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                             .withUsername("flinkuser")
                             .withPassword("flinkpw")
                             .withNetwork(NETWORK)
-                            .withNetworkAliases("mysql")
-                            .withLogConsumer(new Slf4jLogConsumer(LOG));
+                            .withNetworkAliases("mysql");
 
     @ClassRule
     public static final DorisContainer DORIS =
-            new DorisContainer(NETWORK)
-                    .withNetworkAliases("doris")
-                    .withLogConsumer(new Slf4jLogConsumer(LOG));
+            new DorisContainer(NETWORK).withNetworkAliases("doris");
 
     protected final UniqueDatabase mysqlInventoryDatabase =
             new UniqueDatabase(MYSQL, "mysql_inventory", MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
@@ -110,14 +104,13 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
         new LogMessageWaitStrategy()
                 .withRegEx(".*get heartbeat from FE.*")
                 .withTimes(1)
-                .withStartupTimeout(
-                        Duration.of(DEFAULT_STARTUP_TIMEOUT_SECONDS, ChronoUnit.SECONDS))
+                .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT)
                 .waitUntilReady(DORIS);
 
         while (!checkBackendAvailability()) {
             try {
                 if (System.currentTimeMillis() - startWaitingTimestamp
-                        > DEFAULT_STARTUP_TIMEOUT_SECONDS * 1000) {
+                        > DEFAULT_STARTUP_TIMEOUT.toMillis()) {
                     throw new RuntimeException("Doris backend startup timed out.");
                 }
                 LOG.info("Waiting for backends to be available");
@@ -175,6 +168,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
 
     @Test
     public void testSyncWholeDatabase() throws Exception {
+        String databaseName = mysqlInventoryDatabase.getDatabaseName();
         String pipelineJob =
                 String.format(
                         "source:\n"
@@ -199,7 +193,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                                 + "  parallelism: %d",
                         MYSQL_TEST_USER,
                         MYSQL_TEST_PASSWORD,
-                        mysqlInventoryDatabase.getDatabaseName(),
+                        databaseName,
                         DORIS.getUsername(),
                         DORIS.getPassword(),
                         parallelism);
@@ -210,8 +204,19 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
         waitUntilJobRunning(Duration.ofSeconds(30));
         LOG.info("Pipeline job is running");
 
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | INT | Yes | true | null",
+                        "name | VARCHAR(765) | Yes | false | flink",
+                        "description | VARCHAR(1536) | Yes | false | null",
+                        "weight | FLOAT | Yes | false | null",
+                        "enum_c | TEXT | Yes | false | red",
+                        "json_c | TEXT | Yes | false | null",
+                        "point_c | TEXT | Yes | false | null"));
         validateSinkResult(
-                mysqlInventoryDatabase.getDatabaseName(),
+                databaseName,
                 "products",
                 7,
                 Arrays.asList(
@@ -225,8 +230,16 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                         "108 | jacket | water resistent black wind breaker | 0.1 | null | null | null",
                         "109 | spare tire | 24 inch spare tire | 22.2 | null | null | null"));
 
+        validateSinkSchema(
+                databaseName,
+                "customers",
+                Arrays.asList(
+                        "id | INT | Yes | true | null",
+                        "name | VARCHAR(765) | Yes | false | flink",
+                        "address | VARCHAR(3072) | Yes | false | null",
+                        "phone_number | VARCHAR(1536) | Yes | false | null"));
         validateSinkResult(
-                mysqlInventoryDatabase.getDatabaseName(),
+                databaseName,
                 "customers",
                 4,
                 Arrays.asList(
@@ -240,9 +253,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
         String mysqlJdbcUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
-                        mysqlInventoryDatabase.getDatabaseName());
+                        MYSQL.getHost(), MYSQL.getDatabasePort(), databaseName);
         try (Connection conn =
                         DriverManager.getConnection(
                                 mysqlJdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
@@ -252,7 +263,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                     "INSERT INTO products VALUES (default,'jacket','water resistent white wind breaker',0.2, null, null, null);"); // 110
 
             validateSinkResult(
-                    mysqlInventoryDatabase.getDatabaseName(),
+                    databaseName,
                     "products",
                     7,
                     Arrays.asList(
@@ -269,39 +280,65 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
 
             stat.execute("UPDATE products SET description='18oz carpenter hammer' WHERE id=106;");
             stat.execute("UPDATE products SET weight='5.1' WHERE id=107;");
+            validateSinkResult(
+                    databaseName,
+                    "products",
+                    7,
+                    Arrays.asList(
+                            "101 | scooter | Small 2-wheel scooter | 3.14 | red | {\"key1\": \"value1\"} | {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                            "102 | car battery | 12V car battery | 8.1 | white | {\"key2\": \"value2\"} | {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                            "103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.8 | red | {\"key3\": \"value3\"} | {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                            "104 | hammer | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                            "105 | hammer | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                            "106 | hammer | 18oz carpenter hammer | 1.0 | null | null | null",
+                            "107 | rocks | box of assorted rocks | 5.1 | null | null | null",
+                            "108 | jacket | water resistent black wind breaker | 0.1 | null | null | null",
+                            "109 | spare tire | 24 inch spare tire | 22.2 | null | null | null",
+                            "110 | jacket | water resistent white wind breaker | 0.2 | null | null | null"));
 
             // modify table schema
             stat.execute("ALTER TABLE products DROP COLUMN point_c;");
-            stat.execute("DELETE FROM products WHERE id=101;");
+            validateSinkSchema(
+                    databaseName,
+                    "products",
+                    Arrays.asList(
+                            "id | INT | Yes | true | null",
+                            "name | VARCHAR(765) | Yes | false | flink",
+                            "description | VARCHAR(1536) | Yes | false | null",
+                            "weight | FLOAT | Yes | false | null",
+                            "enum_c | TEXT | Yes | false | red",
+                            "json_c | TEXT | Yes | false | null"));
 
+            stat.execute("DELETE FROM products WHERE id=101;");
             stat.execute(
                     "INSERT INTO products VALUES (default,'scooter','Big 2-wheel scooter ',5.18, null, null);"); // 111
             stat.execute(
                     "INSERT INTO products VALUES (default,'finally', null, 2.14, null, null);"); // 112
+            validateSinkResult(
+                    databaseName,
+                    "products",
+                    7,
+                    Arrays.asList(
+                            "102 | car battery | 12V car battery | 8.1 | white | {\"key2\": \"value2\"} | null",
+                            "103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.8 | red | {\"key3\": \"value3\"} | null",
+                            "104 | hammer | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | null",
+                            "105 | hammer | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | null",
+                            "106 | hammer | 18oz carpenter hammer | 1.0 | null | null | null",
+                            "107 | rocks | box of assorted rocks | 5.1 | null | null | null",
+                            "108 | jacket | water resistent black wind breaker | 0.1 | null | null | null",
+                            "109 | spare tire | 24 inch spare tire | 22.2 | null | null | null",
+                            "110 | jacket | water resistent white wind breaker | 0.2 | null | null | null",
+                            "111 | scooter | Big 2-wheel scooter  | 5.18 | null | null | null",
+                            "112 | finally | null | 2.14 | null | null | null"));
         } catch (SQLException e) {
             LOG.error("Update table for CDC failed.", e);
             throw e;
         }
-        validateSinkResult(
-                mysqlInventoryDatabase.getDatabaseName(),
-                "products",
-                7,
-                Arrays.asList(
-                        "102 | car battery | 12V car battery | 8.1 | white | {\"key2\": \"value2\"} | null",
-                        "103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.8 | red | {\"key3\": \"value3\"} | null",
-                        "104 | hammer | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | null",
-                        "105 | hammer | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | null",
-                        "106 | hammer | 18oz carpenter hammer | 1.0 | null | null | null",
-                        "107 | rocks | box of assorted rocks | 5.1 | null | null | null",
-                        "108 | jacket | water resistent black wind breaker | 0.1 | null | null | null",
-                        "109 | spare tire | 24 inch spare tire | 22.2 | null | null | null",
-                        "110 | jacket | water resistent white wind breaker | 0.2 | null | null | null",
-                        "111 | scooter | Big 2-wheel scooter  | 5.18 | null | null | null",
-                        "112 | finally | null | 2.14 | null | null | null"));
     }
 
     @Test
     public void testComplexDataTypes() throws Exception {
+        String databaseName = complexDataTypesDatabase.getDatabaseName();
         String pipelineJob =
                 String.format(
                         "source:\n"
@@ -330,32 +367,87 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                                 + "  parallelism: %d",
                         MYSQL_TEST_USER,
                         MYSQL_TEST_PASSWORD,
-                        complexDataTypesDatabase.getDatabaseName(),
+                        databaseName,
                         DORIS.getUsername(),
                         DORIS.getPassword(),
-                        complexDataTypesDatabase.getDatabaseName(),
+                        databaseName,
                         parallelism);
         Path mysqlCdcJar = TestUtils.getResource("mysql-cdc-pipeline-connector.jar");
         Path dorisCdcConnector = TestUtils.getResource("doris-cdc-pipeline-connector.jar");
         Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
         submitPipelineJob(pipelineJob, mysqlCdcJar, dorisCdcConnector, mysqlDriverJar);
         waitUntilJobRunning(Duration.ofSeconds(30));
-        LOG.info("Pipeline job is running");
+
+        LOG.info("Verifying snapshot stage of DATA_TYPES_TABLE...");
+        validateSinkSchema(
+                databaseName,
+                "DATA_TYPES_TABLE",
+                Arrays.asList(
+                        "id | INT | Yes | true | null",
+                        "tiny_c | TINYINT | Yes | false | null",
+                        "tiny_un_c | SMALLINT | Yes | false | null",
+                        "tiny_un_z_c | SMALLINT | Yes | false | null",
+                        "small_c | SMALLINT | Yes | false | null",
+                        "small_un_c | INT | Yes | false | null",
+                        "small_un_z_c | INT | Yes | false | null",
+                        "medium_c | INT | Yes | false | null",
+                        "medium_un_c | INT | Yes | false | null",
+                        "medium_un_z_c | INT | Yes | false | null",
+                        "int_c | INT | Yes | false | null",
+                        "int_un_c | BIGINT | Yes | false | null",
+                        "int_un_z_c | BIGINT | Yes | false | null",
+                        "int11_c | INT | Yes | false | null",
+                        "big_c | BIGINT | Yes | false | null",
+                        "varchar_c | VARCHAR(765) | Yes | false | null",
+                        "char_c | CHAR(9) | Yes | false | null",
+                        "real_c | DOUBLE | Yes | false | null",
+                        "float_c | FLOAT | Yes | false | null",
+                        "float_un_c | FLOAT | Yes | false | null",
+                        "float_un_z_c | FLOAT | Yes | false | null",
+                        "double_c | DOUBLE | Yes | false | null",
+                        "double_un_c | DOUBLE | Yes | false | null",
+                        "double_un_z_c | DOUBLE | Yes | false | null",
+                        "decimal_c | DECIMAL(8, 4) | Yes | false | null",
+                        "decimal_un_c | DECIMAL(8, 4) | Yes | false | null",
+                        "decimal_un_z_c | DECIMAL(8, 4) | Yes | false | null",
+                        "numeric_c | DECIMAL(6, 0) | Yes | false | null",
+                        "big_decimal_c | TEXT | Yes | false | null",
+                        "bit1_c | BOOLEAN | Yes | false | null",
+                        "tiny1_c | BOOLEAN | Yes | false | null",
+                        "boolean_c | BOOLEAN | Yes | false | null",
+                        "date_c | DATE | Yes | false | null",
+                        "datetime3_c | DATETIME(3) | Yes | false | null",
+                        "datetime6_c | DATETIME(6) | Yes | false | null",
+                        "timestamp_c | DATETIME | Yes | false | null",
+                        "text_c | TEXT | Yes | false | null",
+                        "tiny_blob_c | TEXT | Yes | false | null",
+                        "blob_c | TEXT | Yes | false | null",
+                        "medium_blob_c | TEXT | Yes | false | null",
+                        "long_blob_c | TEXT | Yes | false | null",
+                        "year_c | INT | Yes | false | null",
+                        "enum_c | TEXT | Yes | false | red",
+                        "point_c | TEXT | Yes | false | null",
+                        "geometry_c | TEXT | Yes | false | null",
+                        "linestring_c | TEXT | Yes | false | null",
+                        "polygon_c | TEXT | Yes | false | null",
+                        "multipoint_c | TEXT | Yes | false | null",
+                        "multiline_c | TEXT | Yes | false | null",
+                        "multipolygon_c | TEXT | Yes | false | null",
+                        "geometrycollection_c | TEXT | Yes | false | null",
+                        "FINE | TEXT | Yes | false | null"));
         validateSinkResult(
-                complexDataTypesDatabase.getDatabaseName(),
+                databaseName,
                 "DATA_TYPES_TABLE",
                 52,
                 Collections.singletonList(
                         "1 | 127 | 255 | 255 | 32767 | 65535 | 65535 | 8388607 | 16777215 | 16777215 | 2147483647 | 4294967295 | 4294967295 | 2147483647 | 9223372036854775807 | Hello World | abc | 123.102 | 123.102 | 123.103 | 123.104 | 404.4443 | 404.4444 | 404.4445 | 123.4567 | 123.4568 | 123.4569 | 346 | 34567892.1 | 0 | 1 | 1 | 2020-07-17 | 2020-07-17 18:00:22.0 | 2020-07-17 18:00:22.0 | 2020-07-17 18:00:22 | text | EA== | EA== | EA== | EA== | 2021 | red | {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0} | {\"coordinates\":[[[1,1],[2,1],[2,2],[1,2],[1,1]]],\"type\":\"Polygon\",\"srid\":0} | {\"coordinates\":[[3,0],[3,3],[3,5]],\"type\":\"LineString\",\"srid\":0} | {\"coordinates\":[[[1,1],[2,1],[2,2],[1,2],[1,1]]],\"type\":\"Polygon\",\"srid\":0} | {\"coordinates\":[[1,1],[2,2]],\"type\":\"MultiPoint\",\"srid\":0} | {\"coordinates\":[[[1,1],[2,2],[3,3]],[[4,4],[5,5]]],\"type\":\"MultiLineString\",\"srid\":0} | {\"coordinates\":[[[[0,0],[10,0],[10,10],[0,10],[0,0]]],[[[5,5],[7,5],[7,7],[5,7],[5,5]]]],\"type\":\"MultiPolygon\",\"srid\":0} | {\"geometries\":[{\"type\":\"Point\",\"coordinates\":[10,10]},{\"type\":\"Point\",\"coordinates\":[30,30]},{\"type\":\"LineString\",\"coordinates\":[[15,15],[20,20]]}],\"type\":\"GeometryCollection\",\"srid\":0} | fine"));
 
-        LOG.info("Begin incremental reading stage.");
+        LOG.info("Verifying streaming stage of DATA_TYPES_TABLE...");
         // generate binlogs
         String mysqlJdbcUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
-                        complexDataTypesDatabase.getDatabaseName());
+                        MYSQL.getHost(), MYSQL.getDatabasePort(), databaseName);
         try (Connection conn =
                         DriverManager.getConnection(
                                 mysqlJdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
@@ -385,7 +477,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
             }
 
             validateSinkResult(
-                    complexDataTypesDatabase.getDatabaseName(),
+                    databaseName,
                     "DATA_TYPES_TABLE",
                     52,
                     Arrays.asList(
@@ -400,6 +492,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
 
     @Test
     public void testSchemaEvolution() throws Exception {
+        String databaseName = mysqlInventoryDatabase.getDatabaseName();
         String pipelineJob =
                 String.format(
                         "source:\n"
@@ -425,7 +518,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                                 + "  parallelism: %d",
                         MYSQL_TEST_USER,
                         MYSQL_TEST_PASSWORD,
-                        mysqlInventoryDatabase.getDatabaseName(),
+                        databaseName,
                         DORIS.getUsername(),
                         DORIS.getPassword(),
                         parallelism);
@@ -434,10 +527,21 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
         Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
         submitPipelineJob(pipelineJob, mysqlCdcJar, dorisCdcConnector, mysqlDriverJar);
         waitUntilJobRunning(Duration.ofSeconds(30));
-        LOG.info("Pipeline job is running");
 
+        LOG.info("Verifying snapshot data from `products`...");
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | INT | Yes | true | null",
+                        "name | VARCHAR(765) | Yes | false | flink",
+                        "description | VARCHAR(1536) | Yes | false | null",
+                        "weight | FLOAT | Yes | false | null",
+                        "enum_c | TEXT | Yes | false | red",
+                        "json_c | TEXT | Yes | false | null",
+                        "point_c | TEXT | Yes | false | null"));
         validateSinkResult(
-                mysqlInventoryDatabase.getDatabaseName(),
+                databaseName,
                 "products",
                 7,
                 Arrays.asList(
@@ -451,8 +555,17 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                         "108 | jacket | water resistent black wind breaker | 0.1 | null | null | null",
                         "109 | spare tire | 24 inch spare tire | 22.2 | null | null | null"));
 
+        LOG.info("Verifying snapshot data from `customers`...");
+        validateSinkSchema(
+                databaseName,
+                "customers",
+                Arrays.asList(
+                        "id | INT | Yes | true | null",
+                        "name | VARCHAR(765) | Yes | false | flink",
+                        "address | VARCHAR(3072) | Yes | false | null",
+                        "phone_number | VARCHAR(1536) | Yes | false | null"));
         validateSinkResult(
-                mysqlInventoryDatabase.getDatabaseName(),
+                databaseName,
                 "customers",
                 4,
                 Arrays.asList(
@@ -461,26 +574,23 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                         "103 | user_3 | Shanghai | 123567891234",
                         "104 | user_4 | Shanghai | 123567891234"));
 
-        LOG.info("Begin incremental reading stage.");
-
         // generate binlogs
         String mysqlJdbcUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
-                        mysqlInventoryDatabase.getDatabaseName());
+                        MYSQL.getHost(), MYSQL.getDatabasePort(), databaseName);
         try (Connection conn =
                         DriverManager.getConnection(
                                 mysqlJdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
                 Statement stat = conn.createStatement()) {
 
+            LOG.info("Switching to streaming stage...");
             stat.execute(
                     "INSERT INTO products VALUES (default,'jacket','water resistent white wind breaker',0.2, null, null, null);"); // 110
 
             // Ensure we've entered binlog reading stage
             validateSinkResult(
-                    mysqlInventoryDatabase.getDatabaseName(),
+                    databaseName,
                     "products",
                     7,
                     Arrays.asList(
@@ -496,12 +606,24 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                             "110 | jacket | water resistent white wind breaker | 0.2 | null | null | null"));
 
             // Schema change - Add Column
+            LOG.info("Test Schema Change - Add Column...");
             stat.execute("ALTER TABLE products ADD COLUMN extras INT;");
-            Thread.sleep(1000L);
+            validateSinkSchema(
+                    databaseName,
+                    "products",
+                    Arrays.asList(
+                            "id | INT | Yes | true | null",
+                            "name | VARCHAR(765) | Yes | false | flink",
+                            "description | VARCHAR(1536) | Yes | false | null",
+                            "weight | FLOAT | Yes | false | null",
+                            "enum_c | TEXT | Yes | false | red",
+                            "json_c | TEXT | Yes | false | null",
+                            "point_c | TEXT | Yes | false | null",
+                            "extras | INT | Yes | false | null"));
             stat.execute(
                     "INSERT INTO products VALUES (default, 'blt', 'bacon, lettuce and tomato sandwich', 0.2, null, null, null, 17)"); // 111
             validateSinkResult(
-                    mysqlInventoryDatabase.getDatabaseName(),
+                    databaseName,
                     "products",
                     8,
                     Arrays.asList(
@@ -518,12 +640,24 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                             "111 | blt | bacon, lettuce and tomato sandwich | 0.2 | null | null | null | 17"));
 
             // Schema change - Rename Column
+            LOG.info("Test Schema Change - Rename Column...");
             stat.execute("ALTER TABLE products RENAME COLUMN extras TO extra_col;");
-            Thread.sleep(1000L);
+            validateSinkSchema(
+                    databaseName,
+                    "products",
+                    Arrays.asList(
+                            "id | INT | Yes | true | null",
+                            "name | VARCHAR(765) | Yes | false | flink",
+                            "description | VARCHAR(1536) | Yes | false | null",
+                            "weight | FLOAT | Yes | false | null",
+                            "enum_c | TEXT | Yes | false | red",
+                            "json_c | TEXT | Yes | false | null",
+                            "point_c | TEXT | Yes | false | null",
+                            "extra_col | INT | Yes | false | null"));
             stat.execute(
                     "INSERT INTO products VALUES (default, 'cheeseburger', 'meat patty, cheese slice and onions', 0.1, null, null, null, 18)"); // 112
             validateSinkResult(
-                    mysqlInventoryDatabase.getDatabaseName(),
+                    databaseName,
                     "products",
                     8,
                     Arrays.asList(
@@ -541,12 +675,24 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                             "112 | cheeseburger | meat patty, cheese slice and onions | 0.1 | null | null | null | 18"));
 
             // Schema change - Alter Column Type
-            stat.execute("ALTER TABLE products MODIFY COLUMN extra_col double;");
-            Thread.sleep(1000L);
+            LOG.info("Test Schema Change - Alter Column Type...");
+            stat.execute("ALTER TABLE products MODIFY COLUMN extra_col DOUBLE;");
+            validateSinkSchema(
+                    databaseName,
+                    "products",
+                    Arrays.asList(
+                            "id | INT | Yes | true | null",
+                            "name | VARCHAR(765) | Yes | false | flink",
+                            "description | VARCHAR(1536) | Yes | false | null",
+                            "weight | FLOAT | Yes | false | null",
+                            "enum_c | TEXT | Yes | false | red",
+                            "json_c | TEXT | Yes | false | null",
+                            "point_c | TEXT | Yes | false | null",
+                            "extra_col | DOUBLE | Yes | false | null"));
             stat.execute(
-                    "INSERT INTO products VALUES (default, 'fries', 'potato and salt', 0.05, null, null, null, 19)"); // 113
+                    "INSERT INTO products VALUES (default, 'fries', 'potato and salt', 0.05, null, null, null, 19.5)"); // 113
             validateSinkResult(
-                    mysqlInventoryDatabase.getDatabaseName(),
+                    databaseName,
                     "products",
                     8,
                     Arrays.asList(
@@ -562,15 +708,26 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                             "110 | jacket | water resistent white wind breaker | 0.2 | null | null | null | null",
                             "111 | blt | bacon, lettuce and tomato sandwich | 0.2 | null | null | null | 17.0",
                             "112 | cheeseburger | meat patty, cheese slice and onions | 0.1 | null | null | null | 18.0",
-                            "113 | fries | potato and salt | 0.05 | null | null | null | 19.0"));
+                            "113 | fries | potato and salt | 0.05 | null | null | null | 19.5"));
 
             // Schema change - Drop Column
+            LOG.info("Test Schema Change - Drop Column...");
             stat.execute("ALTER TABLE products DROP COLUMN extra_col;");
-            Thread.sleep(1000L);
+            validateSinkSchema(
+                    databaseName,
+                    "products",
+                    Arrays.asList(
+                            "id | INT | Yes | true | null",
+                            "name | VARCHAR(765) | Yes | false | flink",
+                            "description | VARCHAR(1536) | Yes | false | null",
+                            "weight | FLOAT | Yes | false | null",
+                            "enum_c | TEXT | Yes | false | red",
+                            "json_c | TEXT | Yes | false | null",
+                            "point_c | TEXT | Yes | false | null"));
             stat.execute(
                     "INSERT INTO products VALUES (default, 'mac', 'cheese', 0.025, null, null, null)"); // 114
             validateSinkResult(
-                    mysqlInventoryDatabase.getDatabaseName(),
+                    databaseName,
                     "products",
                     7,
                     Arrays.asList(
@@ -588,52 +745,39 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
                             "112 | cheeseburger | meat patty, cheese slice and onions | 0.1 | null | null | null",
                             "113 | fries | potato and salt | 0.05 | null | null | null",
                             "114 | mac | cheese | 0.025 | null | null | null"));
-        } catch (SQLException e) {
-            LOG.error("Update table for CDC failed.", e);
-            throw e;
-        }
 
-        try (Connection conn =
-                        DriverManager.getConnection(
-                                mysqlJdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
-                Statement stat = conn.createStatement()) {
             stat.execute("TRUNCATE TABLE products;");
-            Thread.sleep(1000L);
+            Thread.sleep(5000L);
             stat.execute(
                     "INSERT INTO products VALUES (default, 'pasta', 'noodles', 0, null, null, null);"); // 1, because truncating resets auto_increment id
-        }
 
-        validateSinkResult(
-                mysqlInventoryDatabase.getDatabaseName(),
-                "products",
-                7,
-                Collections.singletonList("1 | pasta | noodles | 0.0 | null | null | null"));
+            validateSinkResult(
+                    databaseName,
+                    "products",
+                    7,
+                    Collections.singletonList("1 | pasta | noodles | 0.0 | null | null | null"));
 
-        try (Connection conn =
-                        DriverManager.getConnection(
-                                mysqlJdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
-                Statement stat = conn.createStatement()) {
             stat.execute("DROP TABLE products;");
+            Thread.sleep(5000L);
+            SQLException thrown =
+                    assertThrows(
+                            SQLSyntaxErrorException.class,
+                            () -> {
+                                try (Connection connection =
+                                                DriverManager.getConnection(
+                                                        DORIS.getJdbcUrl(
+                                                                databaseName,
+                                                                DORIS.getUsername()));
+                                        Statement statement = connection.createStatement()) {
+                                    statement.executeQuery("SELECT * FROM products;");
+                                }
+                            });
+            assertTrue(
+                    thrown.getMessage()
+                            .contains("errCode = 2, detailMessage = Unknown table 'products'"));
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to trigger schema change.", e);
         }
-        Thread.sleep(1000L);
-
-        SQLException thrown =
-                assertThrows(
-                        SQLSyntaxErrorException.class,
-                        () -> {
-                            try (Connection conn =
-                                            DriverManager.getConnection(
-                                                    DORIS.getJdbcUrl(
-                                                            mysqlInventoryDatabase
-                                                                    .getDatabaseName(),
-                                                            DORIS.getUsername()));
-                                    Statement stat = conn.createStatement()) {
-                                stat.executeQuery("SELECT * FROM products;");
-                            }
-                        });
-        assertTrue(
-                thrown.getMessage()
-                        .contains("errCode = 2, detailMessage = Unknown table 'products'"));
     }
 
     public static void createDorisDatabase(String databaseName) {
@@ -677,65 +821,87 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
     private void validateSinkResult(
             String databaseName, String tableName, int columnCount, List<String> expected)
             throws Exception {
-        validateSqlResults(
+        waitAndVerify(
                 databaseName,
-                String.format("SELECT * FROM `%s`.`%s`;", databaseName, tableName),
+                "SELECT * FROM " + tableName,
                 columnCount,
-                expected);
+                expected,
+                DEFAULT_RESULT_VERIFY_TIMEOUT.toMillis(),
+                true);
     }
 
-    private void validateSqlResults(
-            String databaseName, String sql, int columnCount, List<String> expected)
+    private void validateSinkSchema(String databaseName, String tableName, List<String> expected)
             throws Exception {
-        long startWaitingTimestamp = System.currentTimeMillis();
-        while (true) {
-            if (System.currentTimeMillis() - startWaitingTimestamp
-                    > TESTCASE_TIMEOUT_SECONDS * 1000) {
-                throw new RuntimeException("Doris backend startup timed out.");
-            }
-            List<String> results = new ArrayList<>();
-            try (Connection conn =
-                            DriverManager.getConnection(
-                                    DORIS.getJdbcUrl(databaseName, DORIS.getUsername()));
-                    Statement stat = conn.createStatement()) {
-                ResultSet rs = stat.executeQuery(sql);
+        waitAndVerify(
+                databaseName,
+                "DESCRIBE " + tableName,
+                5,
+                expected,
+                DEFAULT_RESULT_VERIFY_TIMEOUT.toMillis(),
+                false);
+    }
 
-                while (rs.next()) {
-                    List<String> columns = new ArrayList<>();
-                    for (int i = 1; i <= columnCount; i++) {
-                        try {
-                            columns.add(rs.getString(i));
-                        } catch (SQLException ignored) {
-                            // Column count could change after schema evolution
-                            columns.add(null);
-                        }
+    private void waitAndVerify(
+            String databaseName,
+            String sql,
+            int numberOfColumns,
+            List<String> expected,
+            long timeoutMilliseconds,
+            boolean inAnyOrder)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMilliseconds;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                List<String> actual = fetchTableContent(databaseName, sql, numberOfColumns);
+                if (inAnyOrder) {
+                    if (expected.stream()
+                            .sorted()
+                            .collect(Collectors.toList())
+                            .equals(actual.stream().sorted().collect(Collectors.toList()))) {
+                        return;
                     }
-                    results.add(String.join(" | ", columns));
-                }
-
-                if (expected.size() == results.size()) {
-                    assertEqualsInAnyOrder(expected, results);
-                    break;
                 } else {
-                    Thread.sleep(1000);
+                    if (expected.equals(actual)) {
+                        return;
+                    }
                 }
-            } catch (SQLException e) {
-                LOG.info("Validate sink result failure, waiting for next turn...", e);
-                Thread.sleep(1000);
+                LOG.info(
+                        "Executing {}::{} didn't get expected results.\nExpected: {}\n  Actual: {}",
+                        databaseName,
+                        sql,
+                        expected,
+                        actual);
+            } catch (SQLSyntaxErrorException t) {
+                LOG.info("Database {} isn't ready yet. Waiting for the next loop...", databaseName);
+            }
+            Thread.sleep(1000L);
+        }
+        fail(String.format("Failed to verify content of %s::%s.", databaseName, sql));
+    }
+
+    private List<String> fetchTableContent(String databaseName, String sql, int columnCount)
+            throws Exception {
+
+        List<String> results = new ArrayList<>();
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                DORIS.getJdbcUrl(databaseName, DORIS.getUsername()));
+                Statement stat = conn.createStatement()) {
+            ResultSet rs = stat.executeQuery(sql);
+
+            while (rs.next()) {
+                List<String> columns = new ArrayList<>();
+                for (int i = 1; i <= columnCount; i++) {
+                    try {
+                        columns.add(rs.getString(i));
+                    } catch (SQLException ignored) {
+                        // Column count could change after schema evolution
+                        columns.add(null);
+                    }
+                }
+                results.add(String.join(" | ", columns));
             }
         }
-    }
-
-    public static void assertEqualsInAnyOrder(List<String> expected, List<String> actual) {
-        assertTrue(expected != null && actual != null);
-        assertEqualsInOrder(
-                expected.stream().sorted().collect(Collectors.toList()),
-                actual.stream().sorted().collect(Collectors.toList()));
-    }
-
-    public static void assertEqualsInOrder(List<String> expected, List<String> actual) {
-        assertTrue(expected != null && actual != null);
-        assertEquals(expected.size(), actual.size());
-        assertArrayEquals(expected.toArray(new String[0]), actual.toArray(new String[0]));
+        return results;
     }
 }

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MySqlToDorisE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MySqlToDorisE2eITCase.java
@@ -43,6 +43,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -618,7 +619,7 @@ public class MySqlToDorisE2eITCase extends PipelineTestEnvironment {
 
         SQLException thrown =
                 assertThrows(
-                        SQLException.class,
+                        SQLSyntaxErrorException.class,
                         () -> {
                             try (Connection conn =
                                             DriverManager.getConnection(


### PR DESCRIPTION
…to Paimon, StarRocks, and Doris.

This closes FLINK-36193.

FLINK-35243 adds Truncate / Drop table events support at framework level, but no sink connector supports them actually (except `values`). This PR brings schema evolution ability to several compatible sink connectors where such DDLs are supported.