### PR TITLE
[hotfix][runtime] Fix schema operator hanging under extreme parallelized pressure

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/FlushEvent.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/FlushEvent.java
@@ -28,12 +28,23 @@ public class FlushEvent implements Event {
     /** The schema changes from which table. */
     private final TableId tableId;
 
-    public FlushEvent(TableId tableId) {
+    /**
+     * Nonce code to distinguish flush events corresponding to each schema change event from
+     * different subTasks.
+     */
+    private final long nonce;
+
+    public FlushEvent(TableId tableId, long nonce) {
         this.tableId = tableId;
+        this.nonce = nonce;
     }
 
     public TableId getTableId() {
         return tableId;
+    }
+
+    public long getNonce() {
+        return nonce;
     }
 
     @Override
@@ -45,11 +56,16 @@ public class FlushEvent implements Event {
             return false;
         }
         FlushEvent that = (FlushEvent) o;
-        return Objects.equals(tableId, that.tableId);
+        return Objects.equals(tableId, that.tableId) && Objects.equals(nonce, that.nonce);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tableId);
+        return Objects.hash(tableId, nonce);
+    }
+
+    @Override
+    public String toString() {
+        return "FlushEvent{" + "tableId=" + tableId + ", nonce=" + nonce + '}';
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/pom.xml
@@ -48,6 +48,20 @@ limitations under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-composer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-connector-values</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-test-util</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlParallelizedPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlParallelizedPipelineITCase.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source;
+
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.pipeline.PipelineOptions;
+import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
+import org.apache.flink.cdc.composer.PipelineExecution;
+import org.apache.flink.cdc.composer.definition.PipelineDef;
+import org.apache.flink.cdc.composer.definition.SinkDef;
+import org.apache.flink.cdc.composer.definition.SourceDef;
+import org.apache.flink.cdc.composer.flink.FlinkPipelineComposer;
+import org.apache.flink.cdc.connectors.mysql.factory.MySqlDataSourceFactory;
+import org.apache.flink.cdc.connectors.mysql.testutils.UniqueDatabase;
+import org.apache.flink.cdc.connectors.values.ValuesDatabase;
+import org.apache.flink.cdc.connectors.values.factory.ValuesDataFactory;
+import org.apache.flink.cdc.connectors.values.sink.ValuesDataSinkOptions;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
+import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
+import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.getServerId;
+import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.loopCheck;
+import static org.apache.flink.configuration.CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Parallelized Integration test for MySQL connector. */
+public class MySqlParallelizedPipelineITCase extends MySqlSourceTestBase {
+
+    private static final int PARALLELISM = 4;
+    private static final int TEST_TABLE_NUMBER = 100;
+
+    // Always use parent-first classloader for CDC classes.
+    // The reason is that ValuesDatabase uses static field for holding data, we need to make sure
+    // the class is loaded by AppClassloader so that we can verify data in the test case.
+    private static final org.apache.flink.configuration.Configuration MINI_CLUSTER_CONFIG =
+            new org.apache.flink.configuration.Configuration();
+
+    static {
+        MINI_CLUSTER_CONFIG.set(
+                ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
+                Collections.singletonList("org.apache.flink.cdc"));
+    }
+
+    private final PrintStream standardOut = System.out;
+    private final ByteArrayOutputStream outCaptor = new ByteArrayOutputStream();
+
+    private final UniqueDatabase parallelismDatabase =
+            new UniqueDatabase(
+                    MYSQL_CONTAINER, "extreme_parallelism_test_database", TEST_USER, TEST_PASSWORD);
+
+    @Before
+    public void init() {
+        // Take over STDOUT as we need to check the output of values sink
+        System.setOut(new PrintStream(outCaptor));
+        // Initialize in-memory database
+        ValuesDatabase.clear();
+    }
+
+    @After
+    public void cleanup() {
+        System.setOut(standardOut);
+    }
+
+    @Test
+    public void testExtremeParallelizedSchemaChange() throws Exception {
+        final String databaseName = parallelismDatabase.getDatabaseName();
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                MYSQL_CONTAINER.getJdbcUrl(), TEST_USER, TEST_PASSWORD);
+                Statement stat = conn.createStatement()) {
+            stat.execute(String.format("CREATE DATABASE %s;", databaseName));
+            stat.execute(String.format("USE %s;", databaseName));
+            for (int i = 1; i <= TEST_TABLE_NUMBER; i++) {
+                stat.execute(String.format("DROP TABLE IF EXISTS TABLE%d;", i));
+                stat.execute(
+                        String.format(
+                                "CREATE TABLE TABLE%d (ID INT NOT NULL PRIMARY KEY,VERSION VARCHAR(17));",
+                                i));
+                stat.execute(String.format("INSERT INTO TABLE%d VALUES (%d, 'No.%d');", i, i, i));
+            }
+        } catch (SQLException e) {
+            LOG.error("Initialize table failed.", e);
+            throw e;
+        }
+        LOG.info("Table initialized successfully.");
+
+        FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
+
+        // Setup MySQL source
+        Configuration sourceConfig = new Configuration();
+        sourceConfig.set(MySqlDataSourceOptions.HOSTNAME, MYSQL_CONTAINER.getHost());
+        sourceConfig.set(MySqlDataSourceOptions.PORT, MYSQL_CONTAINER.getDatabasePort());
+        sourceConfig.set(MySqlDataSourceOptions.USERNAME, TEST_USER);
+        sourceConfig.set(MySqlDataSourceOptions.PASSWORD, TEST_PASSWORD);
+        sourceConfig.set(MySqlDataSourceOptions.SERVER_TIME_ZONE, "UTC");
+        sourceConfig.set(MySqlDataSourceOptions.TABLES, "\\.*.\\.*");
+        sourceConfig.set(MySqlDataSourceOptions.SERVER_ID, getServerId(PARALLELISM));
+
+        SourceDef sourceDef =
+                new SourceDef(MySqlDataSourceFactory.IDENTIFIER, "MySQL Source", sourceConfig);
+
+        // Setup value sink
+        Configuration sinkConfig = new Configuration();
+        sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
+
+        // Setup pipeline
+        Configuration pipelineConfig = new Configuration();
+        pipelineConfig.set(PipelineOptions.PIPELINE_PARALLELISM, PARALLELISM);
+        pipelineConfig.set(
+                PipelineOptions.PIPELINE_SCHEMA_CHANGE_BEHAVIOR, SchemaChangeBehavior.EVOLVE);
+        PipelineDef pipelineDef =
+                new PipelineDef(
+                        sourceDef,
+                        sinkDef,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        pipelineConfig);
+
+        // Execute the pipeline
+        PipelineExecution execution = composer.compose(pipelineDef);
+        Thread executeThread =
+                new Thread(
+                        () -> {
+                            try {
+                                execution.execute();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        executeThread.start();
+
+        try {
+            loopCheck(
+                    () ->
+                            outCaptor.toString().trim().split("\n").length
+                                    >= TEST_TABLE_NUMBER * (PARALLELISM + 1),
+                    "collect enough rows",
+                    Duration.ofSeconds(120),
+                    Duration.ofSeconds(1));
+        } finally {
+            executeThread.interrupt();
+        }
+
+        // Check the order and content of all received events
+        String outputEvents = outCaptor.toString();
+        assertThat(outputEvents)
+                .contains(
+                        IntStream.rangeClosed(1, TEST_TABLE_NUMBER)
+                                .boxed()
+                                .flatMap(
+                                        i ->
+                                                Stream.concat(
+                                                        IntStream.range(0, PARALLELISM)
+                                                                .boxed()
+                                                                .map(
+                                                                        subTaskId ->
+                                                                                String.format(
+                                                                                        "%d> CreateTableEvent{tableId=%s.TABLE%d, schema=columns={`ID` INT NOT NULL,`VERSION` VARCHAR(17)}, primaryKeys=ID, options=()}",
+                                                                                        subTaskId,
+                                                                                        parallelismDatabase
+                                                                                                .getDatabaseName(),
+                                                                                        i)),
+                                                        Stream.of(
+                                                                String.format(
+                                                                        "> DataChangeEvent{tableId=%s.TABLE%d, before=[], after=[%d, No.%d], op=INSERT, meta=()}",
+                                                                        parallelismDatabase
+                                                                                .getDatabaseName(),
+                                                                        i,
+                                                                        i,
+                                                                        i))))
+                                .collect(Collectors.toList()));
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/testutils/MySqSourceTestUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/testutils/MySqSourceTestUtils.java
@@ -66,8 +66,6 @@ public class MySqSourceTestUtils {
         return serverId + "-" + (serverId + parallelism);
     }
 
-    private MySqSourceTestUtils() {}
-
     public static void loopCheck(
             Supplier<Boolean> runnable, String description, Duration timeout, Duration interval)
             throws Exception {
@@ -81,4 +79,6 @@ public class MySqSourceTestUtils {
         throw new TimeoutException(
                 "Ran out of time when waiting for " + description + " to success.");
     }
+
+    private MySqSourceTestUtils() {}
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/testutils/MySqSourceTestUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/testutils/MySqSourceTestUtils.java
@@ -20,10 +20,13 @@ package org.apache.flink.cdc.connectors.mysql.testutils;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 /** Test utilities for MySQL event source. */
 public class MySqSourceTestUtils {
@@ -64,4 +67,18 @@ public class MySqSourceTestUtils {
     }
 
     private MySqSourceTestUtils() {}
+
+    public static void loopCheck(
+            Supplier<Boolean> runnable, String description, Duration timeout, Duration interval)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            if (runnable.get()) {
+                return;
+            }
+            Thread.sleep(interval.toMillis());
+        }
+        throw new TimeoutException(
+                "Ran out of time when waiting for " + description + " to success.");
+    }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketAssignOperator.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketAssignOperator.java
@@ -124,7 +124,9 @@ public class BucketAssignOperator extends AbstractStreamOperator<Event>
             output.collect(
                     new StreamRecord<>(
                             new BucketWrapperFlushEvent(
-                                    currentTaskNumber, ((FlushEvent) event).getTableId())));
+                                    currentTaskNumber,
+                                    ((FlushEvent) event).getTableId(),
+                                    ((FlushEvent) event).getNonce())));
             return;
         }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketWrapperEventSerializer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketWrapperEventSerializer.java
@@ -82,6 +82,7 @@ public class BucketWrapperEventSerializer extends TypeSerializerSingleton<Event>
             BucketWrapperFlushEvent bucketWrapperFlushEvent = (BucketWrapperFlushEvent) event;
             dataOutputView.writeInt(bucketWrapperFlushEvent.getBucket());
             tableIdSerializer.serialize(bucketWrapperFlushEvent.getTableId(), dataOutputView);
+            dataOutputView.writeLong(bucketWrapperFlushEvent.getNonce());
         }
     }
 
@@ -90,7 +91,7 @@ public class BucketWrapperEventSerializer extends TypeSerializerSingleton<Event>
         EventClass eventClass = enumSerializer.deserialize(source);
         if (eventClass.equals(EventClass.BUCKET_WRAPPER_FLUSH_EVENT)) {
             return new BucketWrapperFlushEvent(
-                    source.readInt(), tableIdSerializer.deserialize(source));
+                    source.readInt(), tableIdSerializer.deserialize(source), source.readLong());
         } else {
             return new BucketWrapperChangeEvent(
                     source.readInt(), (ChangeEvent) eventSerializer.deserialize(source));

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketWrapperFlushEvent.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketWrapperFlushEvent.java
@@ -27,8 +27,8 @@ public class BucketWrapperFlushEvent extends FlushEvent implements BucketWrapper
 
     private final int bucket;
 
-    public BucketWrapperFlushEvent(int bucket, TableId tableId) {
-        super(tableId);
+    public BucketWrapperFlushEvent(int bucket, TableId tableId, long nonce) {
+        super(tableId, nonce);
         this.bucket = bucket;
     }
 

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/RouteE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/RouteE2eITCase.java
@@ -24,7 +24,6 @@ import org.apache.flink.cdc.connectors.mysql.testutils.UniqueDatabase;
 import org.apache.flink.cdc.pipeline.tests.utils.PipelineTestEnvironment;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -41,6 +40,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.IntStream;
 
 /** E2e tests for routing features. */
 @RunWith(Parameterized.class)
@@ -55,6 +55,7 @@ public class RouteE2eITCase extends PipelineTestEnvironment {
     protected static final String MYSQL_DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
     protected static final String INTER_CONTAINER_MYSQL_ALIAS = "mysql";
     protected static final long EVENT_DEFAULT_TIMEOUT = 60000L;
+    protected static final int TEST_TABLE_NUMBER = 100;
 
     @ClassRule
     public static final MySqlContainer MYSQL =
@@ -72,6 +73,9 @@ public class RouteE2eITCase extends PipelineTestEnvironment {
 
     protected final UniqueDatabase routeTestDatabase =
             new UniqueDatabase(MYSQL, "route_test", MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
+
+    protected final UniqueDatabase extremeRouteTestDatabase =
+            new UniqueDatabase(MYSQL, "extreme_route_test", MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
 
     @Before
     public void before() throws Exception {
@@ -814,15 +818,98 @@ public class RouteE2eITCase extends PipelineTestEnvironment {
                 "DataChangeEvent{tableId=NEW_%s.NEW_TABLEDELTA, before=[], after=[10004], op=INSERT, meta=()}");
     }
 
+    @Test
+    public void testExtremeMergeTableRoute() throws Exception {
+        final String databaseName = extremeRouteTestDatabase.getDatabaseName();
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                MYSQL.getJdbcUrl(), MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
+                Statement stat = conn.createStatement()) {
+            stat.execute(String.format("CREATE DATABASE %s;", databaseName));
+            stat.execute(String.format("USE %s;", databaseName));
+            for (int i = 1; i <= TEST_TABLE_NUMBER; i++) {
+                stat.execute(String.format("DROP TABLE IF EXISTS TABLE%d;", i));
+                stat.execute(
+                        String.format(
+                                "CREATE TABLE TABLE%d (ID INT NOT NULL PRIMARY KEY,VERSION VARCHAR(17));",
+                                i));
+                stat.execute(String.format("INSERT INTO TABLE%d VALUES (%d, 'No.%d');", i, i, i));
+            }
+        } catch (SQLException e) {
+            LOG.error("Initialize table failed.", e);
+            throw e;
+        }
+        LOG.info("Table initialized successfully.");
+
+        String pipelineJob =
+                String.format(
+                        "source:\n"
+                                + "  type: mysql\n"
+                                + "  hostname: %s\n"
+                                + "  port: 3306\n"
+                                + "  username: %s\n"
+                                + "  password: %s\n"
+                                + "  tables: %s.\\.*\n"
+                                + "  server-id: 5400-5404\n"
+                                + "  server-time-zone: UTC\n"
+                                + "\n"
+                                + "sink:\n"
+                                + "  type: values\n"
+                                + "\n"
+                                + "pipeline:\n"
+                                + "  parallelism: %d",
+                        INTER_CONTAINER_MYSQL_ALIAS,
+                        MYSQL_TEST_USER,
+                        MYSQL_TEST_PASSWORD,
+                        databaseName,
+                        parallelism);
+        Path mysqlCdcJar = TestUtils.getResource("mysql-cdc-pipeline-connector.jar");
+        Path valuesCdcJar = TestUtils.getResource("values-cdc-pipeline-connector.jar");
+        Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
+        submitPipelineJob(pipelineJob, mysqlCdcJar, valuesCdcJar, mysqlDriverJar);
+        waitUntilJobRunning(Duration.ofSeconds(30));
+
+        LOG.info("Verifying CreateTableEvents...");
+        validateResult(
+                180_000L,
+                IntStream.rangeClosed(1, TEST_TABLE_NUMBER)
+                        .mapToObj(
+                                i ->
+                                        String.format(
+                                                "> CreateTableEvent{tableId=%s.TABLE%d, schema=columns={`ID` INT NOT NULL,`VERSION` VARCHAR(17)}, primaryKeys=ID, options=()}",
+                                                databaseName, i))
+                        .toArray(String[]::new));
+
+        LOG.info("Verifying DataChangeEvents...");
+        validateResult(
+                180_000L,
+                IntStream.rangeClosed(1, TEST_TABLE_NUMBER)
+                        .mapToObj(
+                                i ->
+                                        String.format(
+                                                "> DataChangeEvent{tableId=%s.TABLE%d, before=[], after=[%d, No.%d], op=INSERT, meta=()}",
+                                                databaseName, i, i, i))
+                        .toArray(String[]::new));
+    }
+
     private void validateResult(String... expectedEvents) throws Exception {
+        validateResult(EVENT_DEFAULT_TIMEOUT, expectedEvents);
+    }
+
+    private void validateResult(long timeout, String... expectedEvents) throws Exception {
         for (String event : expectedEvents) {
-            waitUntilSpecificEvent(String.format(event, routeTestDatabase.getDatabaseName()));
+            waitUntilSpecificEvent(
+                    timeout, String.format(event, routeTestDatabase.getDatabaseName()));
         }
     }
 
     private void waitUntilSpecificEvent(String event) throws Exception {
+        waitUntilSpecificEvent(EVENT_DEFAULT_TIMEOUT, event);
+    }
+
+    private void waitUntilSpecificEvent(long timeout, String event) throws Exception {
         boolean result = false;
-        long endTimeout = System.currentTimeMillis() + EVENT_DEFAULT_TIMEOUT;
+        long endTimeout = System.currentTimeMillis() + timeout;
         while (System.currentTimeMillis() < endTimeout) {
             String stdout = taskManagerConsumer.toUtf8String();
             if (stdout.contains(event + "\n")) {
@@ -838,9 +925,5 @@ public class RouteE2eITCase extends PipelineTestEnvironment {
                             + " from stdout: "
                             + taskManagerConsumer.toUtf8String());
         }
-    }
-
-    private void assertNotExists(String event) {
-        Assert.assertFalse(taskManagerConsumer.toUtf8String().contains(event));
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -500,7 +500,7 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
                     Thread.sleep(1000);
                 } else if (response.isWaitingForFlush()) {
                     LOG.info(
-                            "{}> Schema change event (with once {}) has not collected enough flush success events from writers, waiting...",
+                            "{}> Schema change event (with nonce {}) has not collected enough flush success events from writers, waiting...",
                             subTaskId,
                             nonce);
                     Thread.sleep(1000);

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
@@ -180,13 +180,12 @@ public class SchemaRegistry implements OperatorCoordinator, CoordinationRequestH
                         if (event instanceof FlushSuccessEvent) {
                             FlushSuccessEvent flushSuccessEvent = (FlushSuccessEvent) event;
                             LOG.info(
-                                    "Sink subtask {} succeed flushing for table {}.",
+                                    "Sink subtask {} succeed flushing for table {} (nonce: {}).",
                                     flushSuccessEvent.getSubtask(),
-                                    flushSuccessEvent.getTableId().toString());
+                                    flushSuccessEvent.getTableId().toString(),
+                                    flushSuccessEvent.getNonce());
                             requestHandler.flushSuccess(
-                                    flushSuccessEvent.getTableId(),
-                                    flushSuccessEvent.getSubtask(),
-                                    currentParallelism);
+                                    flushSuccessEvent.getSubtask(), flushSuccessEvent.getNonce());
                         } else if (event instanceof SinkWriterRegisterEvent) {
                             requestHandler.registerSinkWriter(
                                     ((SinkWriterRegisterEvent) event).getSubtask());
@@ -273,7 +272,8 @@ public class SchemaRegistry implements OperatorCoordinator, CoordinationRequestH
                             requestHandler.handleSchemaChangeRequest(
                                     schemaChangeRequest, responseFuture);
                         } else if (request instanceof SchemaChangeResultRequest) {
-                            requestHandler.getSchemaChangeResult(responseFuture);
+                            requestHandler.getSchemaChangeResult(
+                                    (SchemaChangeResultRequest) request, responseFuture);
                         } else if (request instanceof GetEvolvedSchemaRequest) {
                             handleGetEvolvedSchemaRequest(
                                     ((GetEvolvedSchemaRequest) request), responseFuture);

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
@@ -148,7 +148,7 @@ public class SchemaRegistryRequestHandler implements Closeable {
                     LOG.info("Event {} has been addressed before, ignoring it.", event);
                     clearCurrentSchemaChangeRequest(nonce);
                     LOG.info(
-                            "SchemaChangeStatus switched from WAITING_FOR_FLUSH to IDLE for request {} due to duplicated request.",
+                            "SchemaChangeStatus is still IDLE for request {} due to duplicated request.",
                             request);
                     response.complete(wrap(SchemaChangeResponse.duplicate()));
                     return;
@@ -183,7 +183,7 @@ public class SchemaRegistryRequestHandler implements Closeable {
                     LOG.info("Event {} is omitted from sending to downstream, ignoring it.", event);
                     clearCurrentSchemaChangeRequest(nonce);
                     LOG.info(
-                            "SchemaChangeStatus switched from WAITING_FOR_FLUSH to IDLE for request {} due to ignored request.",
+                            "SchemaChangeStatus is still IDLE for request {} due to ignored request.",
                             request);
 
                     response.complete(wrap(SchemaChangeResponse.ignored()));

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/FlushSuccessEvent.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/FlushSuccessEvent.java
@@ -36,9 +36,16 @@ public class FlushSuccessEvent implements OperatorEvent {
     /** The schema changes from which table is executing it. */
     private final TableId tableId;
 
-    public FlushSuccessEvent(int subtask, TableId tableId) {
+    /**
+     * Nonce code to distinguish flush events corresponding to each schema change event from
+     * different subTasks.
+     */
+    private final long nonce;
+
+    public FlushSuccessEvent(int subtask, TableId tableId, long nonce) {
         this.subtask = subtask;
         this.tableId = tableId;
+        this.nonce = nonce;
     }
 
     public int getSubtask() {
@@ -47,6 +54,10 @@ public class FlushSuccessEvent implements OperatorEvent {
 
     public TableId getTableId() {
         return tableId;
+    }
+
+    public long getNonce() {
+        return nonce;
     }
 
     @Override
@@ -58,11 +69,13 @@ public class FlushSuccessEvent implements OperatorEvent {
             return false;
         }
         FlushSuccessEvent that = (FlushSuccessEvent) o;
-        return subtask == that.subtask && Objects.equals(tableId, that.tableId);
+        return subtask == that.subtask
+                && Objects.equals(tableId, that.tableId)
+                && nonce == that.nonce;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subtask, tableId);
+        return Objects.hash(subtask, tableId, nonce);
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/SchemaChangeRequest.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/SchemaChangeRequest.java
@@ -38,12 +38,18 @@ public class SchemaChangeRequest implements CoordinationRequest {
     private final SchemaChangeEvent schemaChangeEvent;
     /** The ID of subTask that initiated the request. */
     private final int subTaskId;
+    /**
+     * Nonce code to distinguish flush events corresponding to each schema change event from
+     * different subTasks.
+     */
+    private final long nonce;
 
     public SchemaChangeRequest(
-            TableId tableId, SchemaChangeEvent schemaChangeEvent, int subTaskId) {
+            TableId tableId, SchemaChangeEvent schemaChangeEvent, int subTaskId, long nonce) {
         this.tableId = tableId;
         this.schemaChangeEvent = schemaChangeEvent;
         this.subTaskId = subTaskId;
+        this.nonce = nonce;
     }
 
     public TableId getTableId() {
@@ -58,6 +64,10 @@ public class SchemaChangeRequest implements CoordinationRequest {
         return subTaskId;
     }
 
+    public long getNonce() {
+        return nonce;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -69,11 +79,12 @@ public class SchemaChangeRequest implements CoordinationRequest {
         SchemaChangeRequest that = (SchemaChangeRequest) o;
         return Objects.equals(tableId, that.tableId)
                 && Objects.equals(schemaChangeEvent, that.schemaChangeEvent)
-                && subTaskId == that.subTaskId;
+                && subTaskId == that.subTaskId
+                && nonce == that.nonce;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tableId, schemaChangeEvent, subTaskId);
+        return Objects.hash(tableId, schemaChangeEvent, subTaskId, nonce);
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/SchemaChangeResponse.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/SchemaChangeResponse.java
@@ -57,6 +57,10 @@ public class SchemaChangeResponse implements CoordinationResponse {
         return new SchemaChangeResponse(Collections.emptyList(), ResponseCode.IGNORED);
     }
 
+    public static SchemaChangeResponse waitingForFlush() {
+        return new SchemaChangeResponse(Collections.emptyList(), ResponseCode.WAITING_FOR_FLUSH);
+    }
+
     private SchemaChangeResponse(
             List<SchemaChangeEvent> schemaChangeEvents, ResponseCode responseCode) {
         this.schemaChangeEvents = schemaChangeEvents;
@@ -77,6 +81,10 @@ public class SchemaChangeResponse implements CoordinationResponse {
 
     public boolean isIgnored() {
         return ResponseCode.IGNORED.equals(responseCode);
+    }
+
+    public boolean isWaitingForFlush() {
+        return ResponseCode.WAITING_FOR_FLUSH.equals(responseCode);
     }
 
     public List<SchemaChangeEvent> getSchemaChangeEvents() {
@@ -129,6 +137,7 @@ public class SchemaChangeResponse implements CoordinationResponse {
         ACCEPTED,
         BUSY,
         DUPLICATE,
-        IGNORED
+        IGNORED,
+        WAITING_FOR_FLUSH
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/SchemaChangeResultRequest.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/event/SchemaChangeResultRequest.java
@@ -28,4 +28,36 @@ import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 public class SchemaChangeResultRequest implements CoordinationRequest {
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * Nonce code to distinguish flush events corresponding to each schema change event from
+     * different subTasks.
+     */
+    private final long nonce;
+
+    public SchemaChangeResultRequest(long nonce) {
+        this.nonce = nonce;
+    }
+
+    public long getNonce() {
+        return nonce;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SchemaChangeResultRequest that = (SchemaChangeResultRequest) o;
+        return nonce == that.nonce;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(nonce);
+    }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkFunctionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkFunctionOperator.java
@@ -113,7 +113,7 @@ public class DataSinkFunctionOperator extends StreamSink<Event> {
     private void handleFlushEvent(FlushEvent event) throws Exception {
         userFunction.finish();
         schemaEvolutionClient.notifyFlushSuccess(
-                getRuntimeContext().getIndexOfThisSubtask(), event.getTableId());
+                getRuntimeContext().getIndexOfThisSubtask(), event.getTableId(), event.getNonce());
     }
 
     private void emitLatestSchema(TableId tableId) throws Exception {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkWriterOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkWriterOperator.java
@@ -199,7 +199,7 @@ public class DataSinkWriterOperator<CommT> extends AbstractStreamOperator<Commit
     private void handleFlushEvent(FlushEvent event) throws Exception {
         copySinkWriter.flush(false);
         schemaEvolutionClient.notifyFlushSuccess(
-                getRuntimeContext().getIndexOfThisSubtask(), event.getTableId());
+                getRuntimeContext().getIndexOfThisSubtask(), event.getTableId(), event.getNonce());
     }
 
     private void emitLatestSchema(TableId tableId) throws Exception {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/SchemaEvolutionClient.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/SchemaEvolutionClient.java
@@ -60,9 +60,10 @@ public class SchemaEvolutionClient {
     }
 
     /** send {@link FlushSuccessEvent} to {@link SchemaRegistry}. */
-    public void notifyFlushSuccess(int subtask, TableId tableId) throws IOException {
+    public void notifyFlushSuccess(int subtask, TableId tableId, long nonce) throws IOException {
         toCoordinator.sendOperatorEventToCoordinator(
-                schemaOperatorID, new SerializedValue<>(new FlushSuccessEvent(subtask, tableId)));
+                schemaOperatorID,
+                new SerializedValue<>(new FlushSuccessEvent(subtask, tableId, nonce)));
     }
 
     public Optional<Schema> getLatestEvolvedSchema(TableId tableId) throws Exception {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/event/EventSerializer.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/event/EventSerializer.java
@@ -61,7 +61,9 @@ public final class EventSerializer extends TypeSerializerSingleton<Event> {
     @Override
     public Event copy(Event from) {
         if (from instanceof FlushEvent) {
-            return new FlushEvent(tableIdSerializer.copy(((FlushEvent) from).getTableId()));
+            return new FlushEvent(
+                    tableIdSerializer.copy(((FlushEvent) from).getTableId()),
+                    ((FlushEvent) from).getNonce());
         } else if (from instanceof SchemaChangeEvent) {
             return schemaChangeEventSerializer.copy((SchemaChangeEvent) from);
         } else if (from instanceof DataChangeEvent) {
@@ -85,6 +87,7 @@ public final class EventSerializer extends TypeSerializerSingleton<Event> {
         if (record instanceof FlushEvent) {
             enumSerializer.serialize(EventClass.FLUSH_EVENT, target);
             tableIdSerializer.serialize(((FlushEvent) record).getTableId(), target);
+            target.writeLong(((FlushEvent) record).getNonce());
         } else if (record instanceof SchemaChangeEvent) {
             enumSerializer.serialize(EventClass.SCHEME_CHANGE_EVENT, target);
             schemaChangeEventSerializer.serialize((SchemaChangeEvent) record, target);
@@ -101,7 +104,7 @@ public final class EventSerializer extends TypeSerializerSingleton<Event> {
         EventClass eventClass = enumSerializer.deserialize(source);
         switch (eventClass) {
             case FLUSH_EVENT:
-                return new FlushEvent(tableIdSerializer.deserialize(source));
+                return new FlushEvent(tableIdSerializer.deserialize(source), source.readLong());
             case DATA_CHANGE_EVENT:
                 return dataChangeEventSerializer.deserialize(source);
             case SCHEME_CHANGE_EVENT:

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/typeutils/NonceUtils.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/typeutils/NonceUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.runtime.typeutils;
+
+import org.apache.flink.cdc.common.annotation.PublicEvolving;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.FlushEvent;
+import org.apache.flink.cdc.common.event.TableId;
+
+import java.util.Objects;
+
+/**
+ * Generates schema evolution nonce value and corresponding {@link FlushEvent}s. It is guaranteed to
+ * be unique by combining epoch timestamp, subTaskId, Table ID and schema change event into a long
+ * hashCode.
+ */
+@PublicEvolving
+public class NonceUtils {
+
+    /**
+     * Generating a nonce value with current @{code timestamp}, {@code subTaskId}, {@code tableId},
+     * and {@code schemaChangeEvent}. The higher 32 bits are current UTC timestamp in epoch seconds,
+     * and the lower 32 bits are Java hashCode of the rest parameters.
+     */
+    public static long generateNonce(
+            int timestamp, int subTaskId, TableId tableId, Event schemaChangeEvent) {
+        return (long) timestamp << 32
+                | Integer.toUnsignedLong(Objects.hash(subTaskId, tableId, schemaChangeEvent));
+    }
+
+    /** Generating a {@link FlushEvent} carrying a nonce. */
+    public static FlushEvent generateFlushEvent(
+            int timestamp, int subTaskId, TableId tableId, Event schemaChangeEvent) {
+        return new FlushEvent(
+                tableId, generateNonce(timestamp, subTaskId, tableId, schemaChangeEvent));
+    }
+}

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/partitioning/PrePartitionOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/partitioning/PrePartitionOperatorTest.java
@@ -48,13 +48,15 @@ class PrePartitionOperatorTest {
                     .build();
     private static final int DOWNSTREAM_PARALLELISM = 5;
 
+    private static final long TEST_NONCE = 123456789L;
+
     @Test
     void testBroadcastingSchemaChangeEvent() throws Exception {
         try (EventOperatorTestHarness<PrePartitionOperator, PartitioningEvent> testHarness =
                 createTestHarness()) {
             // Initialization
             testHarness.open();
-            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA);
+            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA, TEST_NONCE);
 
             // CreateTableEvent
             PrePartitionOperator operator = testHarness.getOperator();
@@ -74,11 +76,11 @@ class PrePartitionOperatorTest {
                 createTestHarness()) {
             // Initialization
             testHarness.open();
-            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA);
+            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA, TEST_NONCE);
 
             // FlushEvent
             PrePartitionOperator operator = testHarness.getOperator();
-            FlushEvent flushEvent = new FlushEvent(CUSTOMERS);
+            FlushEvent flushEvent = new FlushEvent(CUSTOMERS, TEST_NONCE);
             operator.processElement(new StreamRecord<>(flushEvent));
             assertThat(testHarness.getOutputRecords()).hasSize(DOWNSTREAM_PARALLELISM);
             for (int i = 0; i < DOWNSTREAM_PARALLELISM; i++) {
@@ -94,7 +96,7 @@ class PrePartitionOperatorTest {
                 createTestHarness()) {
             // Initialization
             testHarness.open();
-            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA);
+            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA, 0L);
 
             // DataChangeEvent
             PrePartitionOperator operator = testHarness.getOperator();

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/event/EventSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/event/EventSerializerTest.java
@@ -47,9 +47,9 @@ public class EventSerializerTest extends SerializerTestBase<Event> {
     protected Event[] getTestData() {
         Event[] flushEvents =
                 new Event[] {
-                    new FlushEvent(TableId.tableId("table")),
-                    new FlushEvent(TableId.tableId("schema", "table")),
-                    new FlushEvent(TableId.tableId("namespace", "schema", "table"))
+                    new FlushEvent(TableId.tableId("table"), 1L),
+                    new FlushEvent(TableId.tableId("schema", "table"), 2L),
+                    new FlushEvent(TableId.tableId("namespace", "schema", "table"), 3L)
                 };
         Event[] dataChangeEvents = new DataChangeEventSerializerTest().getTestData();
         Event[] schemaChangeEvents = new SchemaChangeEventSerializerTest().getTestData();

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/event/PartitioningEventSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/event/PartitioningEventSerializerTest.java
@@ -51,9 +51,9 @@ class PartitioningEventSerializerTest extends SerializerTestBase<PartitioningEve
     protected PartitioningEvent[] getTestData() {
         Event[] flushEvents =
                 new Event[] {
-                    new FlushEvent(TableId.tableId("table")),
-                    new FlushEvent(TableId.tableId("schema", "table")),
-                    new FlushEvent(TableId.tableId("namespace", "schema", "table"))
+                    new FlushEvent(TableId.tableId("table"), 1L),
+                    new FlushEvent(TableId.tableId("schema", "table"), 2L),
+                    new FlushEvent(TableId.tableId("namespace", "schema", "table"), 3L)
                 };
         Event[] dataChangeEvents = new DataChangeEventSerializerTest().getTestData();
         Event[] schemaChangeEvents = new SchemaChangeEventSerializerTest().getTestData();

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/EventOperatorTestHarness.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/EventOperatorTestHarness.java
@@ -173,9 +173,9 @@ public class EventOperatorTestHarness<OP extends AbstractStreamOperator<E>, E ex
         return operator;
     }
 
-    public void registerTableSchema(TableId tableId, Schema schema) {
+    public void registerTableSchema(TableId tableId, Schema schema, long nonce) {
         schemaRegistry.handleCoordinationRequest(
-                new SchemaChangeRequest(tableId, new CreateTableEvent(tableId, schema), 0));
+                new SchemaChangeRequest(tableId, new CreateTableEvent(tableId, schema), 0, nonce));
         schemaRegistry.handleApplyEvolvedSchemaChangeRequest(new CreateTableEvent(tableId, schema));
     }
 
@@ -254,7 +254,10 @@ public class EventOperatorTestHarness<OP extends AbstractStreamOperator<E>, E ex
                     schemaRegistryGateway.sendOperatorEventToCoordinator(
                             SINK_OPERATOR_ID,
                             new SerializedValue<>(
-                                    new FlushSuccessEvent(0, ((FlushEvent) event).getTableId())));
+                                    new FlushSuccessEvent(
+                                            0,
+                                            ((FlushEvent) event).getTableId(),
+                                            ((FlushEvent) event).getNonce())));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
This fixes schema operator hanging glitch under extreme parallelized pressure.

---

Previously, `SchemaOperator`s will ask for schema evolve permission first, before sending `FlushEvent`s to downstream sinks. However, Flink regards `FlushEvent`s as normal data records and might block it to align checkpoint barriers. It might cause the following deadlock situation:

* `SchemaOperator` A has obtained schema evolution permission
* `SchemaOperator` B does not get the permission and hangs
* `SchemaOperator` A sends a `FlushEvent`, but after a checkpoint barrier
* `SchemaOperator` B received a checkpoint barrier after the schema change event (which is blocked)

Now, neither A nor B can post any event records to downstream, and the entire job blocks with the following iconic error message (in TM):

```
0> Schema Registry is busy now, waiting for next request...
1> Schema Registry is busy now, waiting for next request...
2> Schema Registry is busy now, waiting for next request...
[Repeated lines]
```

---

This PR changes the schema evolution permission requesting workflow by:

* `SchemaOperator`s emit `FlushEvent` immediately when they received a `SchemaChangeEvent`.
* A schema change request could only be permitted when a) SchemaRegistry is IDLE and b) the requesting `SchemaOperator` has finished data flushing already.

Since `FlushEvent` might be emitted from multiple `SchemaOperator`s simultaneously, a nonce value that is uniquely bound to a schema change event is added into `FlushEvent` payload. `WAITING_FOR_FLUSH` stage is no longer necessary since this state will not block the `SchemaRegistry` but one single `SchemaOperator` now.

```
--------
| IDLE | -------------------A
--------                    |
   ^                        |
    C                       |
     \                      v
------------          ------------
| FINISHED | <-- B -- | APPLYING |
------------          ------------
```

It should be noted that current schema evolution design implicitly assumes that for each table, it won't be schema evolving in subTask A and emits normal data change events without blocking in subTask B at the same time.

So, after a `SchemaOperator` successfully triggered a flush event, there can't be any more uncommitted dirty data got written down since 1) any following data from this subTask is still being blocked and 2) other subTask can't carry any data belonging to this tableId (according to our previous guarantee).